### PR TITLE
Refactor get_ip method to handle hostname resolution errors and raise exception

### DIFF
--- a/src/ctek/nanogrid_air.py
+++ b/src/ctek/nanogrid_air.py
@@ -83,12 +83,11 @@ class NanogridAir:
 
     async def get_ip(self, hostname: str = "ctek-ng-air.local") -> str | None:
         try:
-            ip = socket.gethostbyname(hostname)
-            if ip:
-                return ip
-        except socket.gaierror:
-            return None
-        return None
+            return socket.gethostbyname(hostname)
+        except socket.gaierror as e:
+            raise ConnectionError(
+                "Could not resolve hostname '" + hostname + "'"
+            ) from e
 
     async def _initialize(self) -> None:
         if not self._initialized:

--- a/src/ctek/nanogrid_air.py
+++ b/src/ctek/nanogrid_air.py
@@ -95,6 +95,9 @@ class NanogridAir:
                 self.device_ip = await self.get_ip()
             self._initialized = True
 
+    def is_initialized(self) -> bool:
+        return self._initialized
+
     async def _fetch_data(self, endpoint: str) -> dict[str, Any]:
         await self._initialize()
         url = f"http://{self.device_ip}/{endpoint}/"

--- a/src/ctek/nanogrid_air.py
+++ b/src/ctek/nanogrid_air.py
@@ -1,43 +1,56 @@
+import logging
 import socket
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import Any
 
 import aiohttp
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
-class DeviceInfo:
+class BaseDataClass:
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    def __str__(self) -> str:
+        return f"{self.to_dict()}"
+
+
+@dataclass
+class DeviceInfo(BaseDataClass):
     serial: str
     firmware: str
     mac: str
 
 
 @dataclass
-class ChargeboxInfo:
+class ChargeboxInfo(BaseDataClass):
     identity: str
     serial: str
     firmware: str
     endpoint: str
     port: int
     state: str
+    pinned: bool
 
 
 @dataclass
-class MeterInfo:
+class MeterInfo(BaseDataClass):
     vendor: str
     type: str
     id: str
 
 
 @dataclass
-class OTAInfo:
+class OTAInfo(BaseDataClass):
     status: int
     version: str
     progress: int
 
 
 @dataclass
-class DeviceStatus:
+class DeviceStatus(BaseDataClass):
     device_info: DeviceInfo
     chargebox_info: ChargeboxInfo
     meter_info: MeterInfo
@@ -45,7 +58,7 @@ class DeviceStatus:
 
 
 @dataclass
-class MeterData:
+class MeterData(BaseDataClass):
     active_power_in: float
     active_power_out: float
     current: list[float]
@@ -55,7 +68,7 @@ class MeterData:
 
 
 @dataclass
-class MeterRawData:
+class MeterRawData(BaseDataClass):
     result: str
     cpu_time_ms: int
     length: int
@@ -63,14 +76,14 @@ class MeterRawData:
 
 
 @dataclass
-class EVSEInfo:
+class EVSEInfo(BaseDataClass):
     id: int
     state: int
     current: list[float]
 
 
 @dataclass
-class EVSEData:
+class EVSEData(BaseDataClass):
     cb_id: str
     connection_status: str
     evse: list[EVSEInfo] = field(default_factory=list)
@@ -109,6 +122,7 @@ class NanogridAir:
         async with aiohttp.ClientSession() as session, session.get(url) as response:
             response.raise_for_status()
             data = await response.json()
+            logger.debug(f"Received data from {url}: {data}")
             if isinstance(data, list):
                 return {str(idx): item for idx, item in enumerate(data)}
             elif isinstance(data, dict):
@@ -118,16 +132,49 @@ class NanogridAir:
 
     async def fetch_status(self) -> DeviceStatus:
         data: dict[str, Any] = await self._fetch_data("status")
-        return DeviceStatus(
-            device_info=DeviceInfo(**data["deviceInfo"]),
-            chargebox_info=ChargeboxInfo(**data["chargeboxInfo"]),
-            meter_info=MeterInfo(**data["meterInfo"]),
-            ota_info=OTAInfo(**data["otaInfo"]),
+
+        # Get device info fields with default values if they are missing
+        device_info_data = data.get("deviceInfo", {})
+        device_info = DeviceInfo(
+            serial=device_info_data.get("serial", ""),
+            firmware=device_info_data.get("firmware", ""),
+            mac=device_info_data.get("mac", ""),
         )
 
-    async def fetch_mac(self) -> str:
-        status = await self.fetch_status()
-        return status.device_info.mac
+        # Get chargebox info fields with default values if they are missing
+        chargebox_info_data = data.get("chargeboxInfo", {})
+        chargebox_info = ChargeboxInfo(
+            identity=chargebox_info_data.get("identity", ""),
+            serial=chargebox_info_data.get("serial", ""),
+            firmware=chargebox_info_data.get("firmware", ""),
+            endpoint=chargebox_info_data.get("endpoint", ""),
+            port=chargebox_info_data.get("port", 0),
+            state=chargebox_info_data.get("state", ""),
+            pinned=chargebox_info_data.get("pinned", False),
+        )
+
+        # Get meter info fields with default values if they are missing
+        meter_info_data = data.get("meterInfo", {})
+        meter_info = MeterInfo(
+            vendor=meter_info_data.get("vendor", ""),
+            type=meter_info_data.get("type", ""),
+            id=meter_info_data.get("id", ""),
+        )
+
+        # Get OTA info fields with default values if they are missing
+        ota_info_data = data.get("otaInfo", {})
+        ota_info = OTAInfo(
+            status=ota_info_data.get("status", 0),
+            version=ota_info_data.get("version", ""),
+            progress=ota_info_data.get("progress", 0),
+        )
+
+        return DeviceStatus(
+            device_info=device_info,
+            chargebox_info=chargebox_info,
+            meter_info=meter_info,
+            ota_info=ota_info,
+        )
 
     async def fetch_meter_data(self) -> MeterData:
         data: dict[str, Any] = await self._fetch_data("meter")

--- a/tests/manual_test_ng_air.py
+++ b/tests/manual_test_ng_air.py
@@ -31,3 +31,10 @@ async def test_nanogrid_air_print_meterraw():
 async def test_nanogrid_air_print_evse():
     evse = await NanogridAir().fetch_evse()
     print(f"EVSE data: {evse}")
+
+
+@pytest.mark.asyncio
+async def test_invalid_ip():
+    with pytest.raises(ConnectionError):
+        evse = await NanogridAir(device_ip="1.2.3.4").fetch_evse()
+        print(f"EVSE data: {evse}")

--- a/tests/manual_test_ng_air.py
+++ b/tests/manual_test_ng_air.py
@@ -12,13 +12,7 @@ async def test_nanogrid_air_print_ip():
 @pytest.mark.asyncio
 async def test_nanogrid_air_print_status():
     status = await NanogridAir().fetch_status()
-    print(f"Status: {status}")
-
-
-@pytest.mark.asyncio
-async def test_nanogrid_air_print_mac():
-    mac = await NanogridAir().fetch_mac()
-    print(f"MAC address: {mac}")
+    print(f"Status: {status.device_info.mac}")
 
 
 @pytest.mark.asyncio

--- a/tests/test_nanogrid_air.py
+++ b/tests/test_nanogrid_air.py
@@ -2,16 +2,12 @@ import unittest
 from unittest.mock import patch
 
 from ctek.nanogrid_air import (
-    ChargeboxInfo,
-    DeviceInfo,
     DeviceStatus,
     EVSEData,
     EVSEInfo,
     MeterData,
-    MeterInfo,
     MeterRawData,
     NanogridAir,
-    OTAInfo,
 )
 
 
@@ -21,7 +17,7 @@ class TestNanogridAir(unittest.IsolatedAsyncioTestCase):
             return {
                 "deviceInfo": {
                     "serial": "123456",
-                    "firmware": "v1.0",
+                    "firmware": "v1.2.0",
                     "mac": "00:11:22:33:44:55",
                 },
                 "chargeboxInfo": {
@@ -31,6 +27,39 @@ class TestNanogridAir(unittest.IsolatedAsyncioTestCase):
                     "endpoint": "http://example.com",
                     "port": 8080,
                     "state": "connected",
+                    "pinned": False,
+                },
+                "meterInfo": {"vendor": "vendor", "type": "type", "id": "id"},
+                "otaInfo": {"status": 1, "version": "v2.1", "progress": 50},
+            }
+
+        with patch.object(NanogridAir, "_fetch_data", side_effect=mock_fetch_data):
+            nanogrid_air = NanogridAir()
+            status = await nanogrid_air.fetch_status()
+
+            self.assertIsInstance(status, DeviceStatus)
+            self.assertEqual(status.device_info.serial, "123456")
+            self.assertEqual(status.chargebox_info.serial, "789")
+            self.assertEqual(status.meter_info.vendor, "vendor")
+            self.assertEqual(status.ota_info.status, 1)
+
+    async def test_fetch_status_unimplemented_or_missing_field(self):
+        async def mock_fetch_data(endpoint):
+            return {
+                "deviceInfo": {
+                    "serial": "123456",
+                    "firmware": "v1.2.0",
+                    "mac": "00:11:22:33:44:55",
+                },
+                "chargeboxInfo": {
+                    "identity": "abc",
+                    "serial": "789",
+                    "firmware": "v2.0",
+                    "endpoint": "http://example.com",
+                    "port": 8080,
+                    "state": "connected",
+                    # "pinned": False, # Missing field
+                    "new_field_not_implemented": False,  # Unimplemented field
                 },
                 "meterInfo": {"vendor": "vendor", "type": "type", "id": "id"},
                 "otaInfo": {"status": 1, "version": "v2.1", "progress": 50},
@@ -49,12 +78,12 @@ class TestNanogridAir(unittest.IsolatedAsyncioTestCase):
     async def test_fetch_meter_data(self):
         async def mock_fetch_data(endpoint):
             return {
-                "activePowerIn": 100,
-                "activePowerOut": 50,
-                "current": [1, 2, 3],
-                "voltage": [220, 230, 240],
-                "totalEnergyActiveImport": 500,
-                "totalEnergyActiveExport": 200,
+                "activePowerIn": 0.01,
+                "activePowerOut": 0,
+                "current": [0.2, 0, 0],
+                "voltage": [225.1, 228.1, 227.5],
+                "totalEnergyActiveImport": 2853,
+                "totalEnergyActiveExport": 0,
             }
 
         with patch.object(NanogridAir, "_fetch_data", side_effect=mock_fetch_data):
@@ -62,32 +91,28 @@ class TestNanogridAir(unittest.IsolatedAsyncioTestCase):
             meter_data = await nanogrid_air.fetch_meter_data()
 
             self.assertIsInstance(meter_data, MeterData)
-            self.assertEqual(meter_data.active_power_in, 100)
-            self.assertEqual(meter_data.total_energy_active_import, 500)
+            self.assertEqual(meter_data.active_power_in, 0.01)
+            self.assertEqual(meter_data.total_energy_active_import, 2853)
 
-    async def test_fetch_mac(self):
-        async def mock_fetch_status():
-            return DeviceStatus(
-                device_info=DeviceInfo(
-                    serial="123456", firmware="v1.0", mac="00:11:22:33:44:55"
-                ),
-                chargebox_info=ChargeboxInfo(
-                    identity="abc",
-                    serial="789",
-                    firmware="v2.0",
-                    endpoint="http://example.com",
-                    port=8080,
-                    state="connected",
-                ),
-                meter_info=MeterInfo(vendor="vendor", type="type", id="id"),
-                ota_info=OTAInfo(status=1, version="v2.1", progress=50),
-            )
+    async def test_fetch_meter_data_unimplemented_field(self):
+        async def mock_fetch_data(endpoint):
+            return {
+                "activePowerIn": 0.01,
+                "activePowerOut": 0,
+                "current": [0.2, 0, 0],
+                "voltage": [225.1, 228.1, 227.5],
+                "totalEnergyActiveImport": 2853,
+                "totalEnergyActiveExport": 0,
+                "new_field_not_implemented": 0,
+            }
 
-        with patch.object(NanogridAir, "fetch_status", side_effect=mock_fetch_status):
+        with patch.object(NanogridAir, "_fetch_data", side_effect=mock_fetch_data):
             nanogrid_air = NanogridAir()
-            mac = await nanogrid_air.fetch_mac()
+            meter_data = await nanogrid_air.fetch_meter_data()
 
-            self.assertEqual(mac, "00:11:22:33:44:55")
+            self.assertIsInstance(meter_data, MeterData)
+            self.assertEqual(meter_data.active_power_in, 0.01)
+            self.assertEqual(meter_data.total_energy_active_import, 2853)
 
     async def test_fetch_meterraw(self):
         async def mock_fetch_data(endpoint):


### PR DESCRIPTION
Refactored get_ip method to not only return None when getting socket.gaierror. This could cause issues and hide errors for users.

Instead a standard ConnectionError is raised with a descriptive text to the user.

Added baseclass to dataclass objects.

Updated initialization